### PR TITLE
Adding initial rules for Q agent workAdding initial rules for Q agent

### DIFF
--- a/.amazonq/rules/terraform_rules.md
+++ b/.amazonq/rules/terraform_rules.md
@@ -1,0 +1,5 @@
+Any AWS resources need to be created using Terraform, and linted using `terraform validate` and `terraform fmt -check`.
+Terraform code should be stored in a directory named `terraform` at the root of the repository.
+State should be stored in S3 in the bucket called 'srhoton-tfstate', in a folder called 'ga-oidc'. 
+The backend configuration should be stored in a file named `backend.tf` in the `terraform` directory.
+All AWS resources should be created in the us-east-1 region.


### PR DESCRIPTION
This pull request updates the Terraform usage guidelines in the `.amazonq/rules/terraform_rules.md` file to standardize the creation and management of AWS resources. 

Updates to Terraform guidelines:

* Added a requirement to use Terraform for creating AWS resources, with mandatory linting using `terraform validate` and `terraform fmt -check`.
* Specified that Terraform code should reside in a `terraform` directory at the root of the repository.
* Defined the S3 bucket (`srhoton-tfstate`) and folder (`ga-oidc`) for storing Terraform state.
* Mandated the use of a `backend.tf` file in the `terraform` directory for backend configuration.
* Stipulated that all AWS resources must be created in the `us-east-1` region.work