### PR TITLE
Add Terraform configuration for GitHub Actions OIDC connection to AWS

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.95.0"
+  hashes = [
+    "h1:PUug/LLWa4GM08rXqnmCVUXj8ibCTvQxgvawhat3bMo=",
+    "zh:20aac8c95edd444e659f235d19fa6af9b259c5a70fce19d400539ee88687e7d4",
+    "zh:29c55846fadd19dde0c5108f74d507c296d6c37cabdd466a96d3721a7c261743",
+    "zh:325fa5cb42d58c9203c279450863c49e534672f7101c067af465f9d7f4be3be5",
+    "zh:4f18c643584f7ba554399c0db3dd1c81629dfc2508a8777890f9f3b80b5213b7",
+    "zh:561e38e9cc6f0be5470c187ea8d51047c4133d9cb74cc1c364a9ebe41f40a06b",
+    "zh:6ec2cceed96ca5e47591ef11686614c663b05e112a814d24246a2739066577b6",
+    "zh:710a227c02b8a50f75a82a7f063d2416e85783e02ed91bb22cc12e7a8e11a3cf",
+    "zh:97a2f5e9bf4cf9a38274eddb7967e1cb4e5b04960c7da3603d9b1c15e18b8626",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:bf6bfb01fff8226d86c1b219d67cd96f37bb9312b17d00340e6ff00dda2dbe82",
+    "zh:cba74d606149cbaaa8dfb69f369f2496b851643a879adc24b11515fcece42b66",
+    "zh:d5a2c36739cab677a48f4856958c96be6f018ff0da50d233ca93a3a21aaceca1",
+    "zh:df5d1466144852fe5da4af0628db6f02b5186c59f683e5085705d9b90cacfbc0",
+    "zh:f82d96b45983b3c73b78dced9e344512b7a9adb06e8c1e3e4f422605efbb756d",
+    "zh:fb523f787077270059a8f3ab52c0fc56257c0b3a06f0219be247c8b15ff0ca2a",
+  ]
+}

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "srhoton-tfstate"
+    key    = "ga-oidc/terraform.tfstate"
+    region = "us-east-1"
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,75 @@
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+# IAM Role for GitHub Actions
+resource "aws_iam_role" "github_actions" {
+  name = "github-actions-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github_actions.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:*:*"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# Create custom policy for S3 bucket access
+resource "aws_iam_policy" "s3_bucket_access" {
+  name        = "github-actions-s3-access"
+  description = "Policy allowing GitHub Actions to manipulate files in the steverhoton.com S3 bucket"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:GetBucketLocation"
+        ]
+        Resource = [
+          "arn:aws:s3:::steverhoton.com",
+          "arn:aws:s3:::steverhoton.com/*"
+        ]
+      }
+    ]
+  })
+}
+
+# Attach policies to the role as needed
+resource "aws_iam_role_policy_attachment" "github_actions_policy" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess" # General read-only access
+}
+
+# Attach S3 bucket policy to the role
+resource "aws_iam_role_policy_attachment" "github_actions_s3_policy" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = aws_iam_policy.s3_bucket_access.arn
+}
+
+# Output the role ARN for use in GitHub Actions workflows
+output "github_actions_role_arn" {
+  value       = aws_iam_role.github_actions.arn
+  description = "ARN of the IAM role for GitHub Actions"
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "us-east-1"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,7 @@
+# Variables can be defined here if needed
+# For example:
+# variable "github_repositories" {
+#   description = "List of GitHub repositories that can assume the role"
+#   type        = list(string)
+#   default     = ["owner/repo"]
+# }


### PR DESCRIPTION
This pull request introduces Terraform configurations to set up an AWS environment for GitHub Actions, including backend configuration, IAM roles, and policies. The changes enable secure integration between GitHub Actions and AWS services, particularly for managing an S3 bucket.

### Backend and Provider Configuration:

* Added S3 backend configuration in `terraform/backend.tf` to store Terraform state in the `srhoton-tfstate` bucket in the `us-east-1` region.
* Configured the AWS provider in `terraform/provider.tf` to use the `us-east-1` region.

### IAM Role and Policy Setup:

* Created an OpenID Connect (OIDC) provider and an IAM role in `terraform/main.tf` for GitHub Actions, allowing it to assume the role via web identity. The role includes a custom policy for accessing the `steverhoton.com` S3 bucket and a general read-only access policy.
* Added outputs in `terraform/main.tf` to expose the IAM role ARN for use in GitHub Actions workflows.

### Lock File and Variables:

* Updated the Terraform lock file (`terraform/.terraform.lock.hcl`) to include the AWS provider version `5.95.0` and its associated hashes.
* Added a placeholder for defining variables in `terraform/variables.tf`, with an example for specifying GitHub repositories.