### PR TITLE
Add CloudFront cache invalidation permissions for distribution E121HA…

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -56,6 +56,29 @@ resource "aws_iam_policy" "s3_bucket_access" {
   })
 }
 
+# Create custom policy for CloudFront cache invalidation
+resource "aws_iam_policy" "cloudfront_invalidation" {
+  name        = "github-actions-cloudfront-invalidation"
+  description = "Policy allowing GitHub Actions to create CloudFront cache invalidations"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "cloudfront:CreateInvalidation",
+          "cloudfront:GetInvalidation",
+          "cloudfront:ListInvalidations"
+        ]
+        Resource = [
+          "arn:aws:cloudfront::*:distribution/E121HAZWT3OMVA"
+        ]
+      }
+    ]
+  })
+}
+
 # Attach policies to the role as needed
 resource "aws_iam_role_policy_attachment" "github_actions_policy" {
   role       = aws_iam_role.github_actions.name
@@ -66,6 +89,12 @@ resource "aws_iam_role_policy_attachment" "github_actions_policy" {
 resource "aws_iam_role_policy_attachment" "github_actions_s3_policy" {
   role       = aws_iam_role.github_actions.name
   policy_arn = aws_iam_policy.s3_bucket_access.arn
+}
+
+# Attach CloudFront invalidation policy to the role
+resource "aws_iam_role_policy_attachment" "github_actions_cloudfront_policy" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = aws_iam_policy.cloudfront_invalidation.arn
 }
 
 # Output the role ARN for use in GitHub Actions workflows


### PR DESCRIPTION
This pull request introduces a new IAM policy and role policy attachment to enable GitHub Actions to perform CloudFront cache invalidations. The changes enhance the infrastructure's ability to automate cache management for CloudFront distributions.

### IAM Policy Updates:
* Added a new IAM policy `aws_iam_policy.cloudfront_invalidation` to allow GitHub Actions to create, get, and list CloudFront cache invalidations for a specific distribution (`arn:aws:cloudfront::*:distribution/E121HAZWT3OMVA`). (`terraform/main.tf`, [terraform/main.tfR59-R81](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028R59-R81))

### Role Policy Attachment:
* Attached the newly created `cloudfront_invalidation` policy to the `github_actions` IAM role via a new `aws_iam_role_policy_attachment` resource. (`terraform/main.tf`, [terraform/main.tfR94-R99](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028R94-R99))…ZWT3OMVA