### PR TITLE
Add full S3 access to srhoton-tfstate bucket for GitHub Actions role

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -56,6 +56,26 @@ resource "aws_iam_policy" "s3_bucket_access" {
   })
 }
 
+# Create policy for full S3 bucket access to srhoton-tfstate
+resource "aws_iam_policy" "s3_tfstate_full_access" {
+  name        = "github-actions-s3-tfstate-full-access"
+  description = "Policy allowing GitHub Actions full access to the srhoton-tfstate S3 bucket"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "s3:*"
+        Resource = [
+          "arn:aws:s3:::srhoton-tfstate",
+          "arn:aws:s3:::srhoton-tfstate/*"
+        ]
+      }
+    ]
+  })
+}
+
 # Create custom policy for CloudFront cache invalidation
 resource "aws_iam_policy" "cloudfront_invalidation" {
   name        = "github-actions-cloudfront-invalidation"
@@ -176,6 +196,12 @@ resource "aws_iam_role_policy_attachment" "github_actions_policy" {
 resource "aws_iam_role_policy_attachment" "github_actions_s3_policy" {
   role       = aws_iam_role.github_actions.name
   policy_arn = aws_iam_policy.s3_bucket_access.arn
+}
+
+# Attach S3 tfstate full access policy to the role
+resource "aws_iam_role_policy_attachment" "github_actions_s3_tfstate_policy" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = aws_iam_policy.s3_tfstate_full_access.arn
 }
 
 # Attach CloudFront invalidation policy to the role


### PR DESCRIPTION
This pull request introduces a new IAM policy and its attachment to enable GitHub Actions to have full access to the `srhoton-tfstate` S3 bucket. The changes include creating the policy and attaching it to the existing IAM role for GitHub Actions.

### IAM Policy Changes:

* **New S3 Full Access Policy**: Added a new `aws_iam_policy` resource named `s3_tfstate_full_access` that grants full access (`s3:*`) to the `srhoton-tfstate` S3 bucket and its contents. (`terraform/main.tf`, [terraform/main.tfR59-R78](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028R59-R78))

### Role Policy Attachment Changes:

* **Attach New Policy to GitHub Actions Role**: Added a new `aws_iam_role_policy_attachment` resource to attach the `s3_tfstate_full_access` policy to the `github_actions` IAM role. (`terraform/main.tf`, [terraform/main.tfR201-R206](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028R201-R206))