### PR TITLE
Add IAM management permissions to GitHub Actions OIDC role

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -186,6 +186,55 @@ resource "aws_iam_policy" "sqs_management" {
   })
 }
 
+# Create custom policy for IAM management
+resource "aws_iam_policy" "iam_management" {
+  name        = "github-actions-iam-management"
+  description = "Policy allowing GitHub Actions to create, modify, and delete IAM policies and roles"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "iam:CreatePolicy",
+          "iam:DeletePolicy",
+          "iam:CreatePolicyVersion",
+          "iam:DeletePolicyVersion",
+          "iam:GetPolicy",
+          "iam:GetPolicyVersion",
+          "iam:ListPolicyVersions",
+          "iam:ListPolicies",
+          "iam:TagPolicy",
+          "iam:UntagPolicy"
+        ]
+        Resource = "arn:aws:iam::*:policy/*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "iam:CreateRole",
+          "iam:DeleteRole",
+          "iam:GetRole",
+          "iam:ListRoles",
+          "iam:UpdateRole",
+          "iam:UpdateRoleDescription",
+          "iam:TagRole",
+          "iam:UntagRole",
+          "iam:AttachRolePolicy",
+          "iam:DetachRolePolicy",
+          "iam:ListAttachedRolePolicies",
+          "iam:ListRolePolicies",
+          "iam:PutRolePolicy",
+          "iam:DeleteRolePolicy",
+          "iam:GetRolePolicy"
+        ]
+        Resource = "arn:aws:iam::*:role/*"
+      }
+    ]
+  })
+}
+
 # Attach policies to the role as needed
 resource "aws_iam_role_policy_attachment" "github_actions_policy" {
   role       = aws_iam_role.github_actions.name
@@ -220,6 +269,12 @@ resource "aws_iam_role_policy_attachment" "github_actions_lambda_policy" {
 resource "aws_iam_role_policy_attachment" "github_actions_sqs_policy" {
   role       = aws_iam_role.github_actions.name
   policy_arn = aws_iam_policy.sqs_management.arn
+}
+
+# Attach IAM management policy to the role
+resource "aws_iam_role_policy_attachment" "github_actions_iam_policy" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = aws_iam_policy.iam_management.arn
 }
 
 # Output the role ARN for use in GitHub Actions workflows


### PR DESCRIPTION
This pull request introduces a new IAM policy and its attachment to the GitHub Actions role in the Terraform configuration. These changes enhance the role's permissions to manage IAM policies and roles, enabling more advanced automation capabilities.

### New IAM Policy for IAM Management:

* **Creation of `aws_iam_policy` resource (`iam_management`)**: A new custom policy (`github-actions-iam-management`) is added to allow GitHub Actions to create, modify, and delete IAM policies and roles. This includes permissions for actions such as `iam:CreatePolicy`, `iam:DeletePolicy`, `iam:CreateRole`, `iam:DeleteRole`, and others, scoped to all policies and roles within the account (`arn:aws:iam::*:policy/*` and `arn:aws:iam::*:role/*`). (`[terraform/main.tfR189-R237](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028R189-R237)`)

### Policy Attachment:

* **Attachment of the new IAM management policy**: The newly created IAM management policy is attached to the existing `github_actions` IAM role using the `aws_iam_role_policy_attachment` resource. This ensures that the role can utilize the permissions defined in the policy. (`[terraform/main.tfR274-R279](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028R274-R279)`)